### PR TITLE
fixed bug when using "every epoch" repeat seed sequence

### DIFF
--- a/StimulusPackages/celltyping-package/+manookinlab/+protocols/SpatialNoise.m
+++ b/StimulusPackages/celltyping-package/+manookinlab/+protocols/SpatialNoise.m
@@ -376,7 +376,7 @@ classdef SpatialNoise < manookinlab.protocols.ManookinLabStageProtocol
             else
                 switch obj.randomSeedSequence
                     case 'every epoch'
-                        obj.seed = obj.start_seed + 1;
+                        obj.seed = obj.start_seed + floor(obj.numEpochsCompleted);
                     case 'every 2 epochs'
                         obj.seed = obj.start_seed + floor(obj.numEpochsCompleted/2);
                     case 'every 3 epochs'


### PR DESCRIPTION
Bug fix: When the randomSeedSequence option is set to 'every epoch', every epoch after the first one uses the same seed (start_seed + 1). Now the seed will be iterated every epoch as intended (start_seed + floor(obj.numEpochsCompleted)).