### PR TITLE
PresentImages presentation duration and visibility control based on frame count

### DIFF
--- a/StimulusPackages/celltyping-package/+manookinlab/+protocols/PresentImages.m
+++ b/StimulusPackages/celltyping-package/+manookinlab/+protocols/PresentImages.m
@@ -85,8 +85,11 @@ classdef PresentImages < manookinlab.protocols.ManookinLabStageProtocol
             obj.outerMaskRadiusPix = obj.rig.getDevice('Stage').um2pix(obj.outerMaskDiameter)/2.0;
             
             % Calcualate the number of flash and gap frames.
-            obj.flashFrames = round(obj.flashTime * 1e-3 * 60);
-            obj.gapFrames = round(obj.gapTime * 1e-3 * 60);
+            obj.preFrames = round((obj.preTime * 1e-3) * obj.expectedRefreshRate);
+            obj.flashFrames = round((obj.flashTime * 1e-3) * obj.expectedRefreshRate);
+            obj.gapFrames = round((obj.gapTime * 1e-3) * obj.expectedRefreshRate);
+            obj.tailFrames = round((obj.tailTime * 1e-3) * obj.expectedRefreshRate);
+            obj.stimFrames = round((obj.flashFrames + obj.gapFrames) * obj.imagesPerEpoch);
             
             % General directory
             try
@@ -147,7 +150,8 @@ classdef PresentImages < manookinlab.protocols.ManookinLabStageProtocol
         function p = createPresentation(obj)
             % Stage presets
             canvasSize = obj.rig.getDevice('Stage').getCanvasSize();     
-            p = stage.core.Presentation((obj.preTime + obj.stimTime + obj.tailTime) * 1e-3);
+            totalTimePerEpoch = ceil((obj.preFrames + obj.stimFrames + obj.tailFrames)/obj.expectedRefreshRate);
+            p = stage.core.Presentation(totalTimePerEpoch);
             
             p.setBackgroundColor(obj.backgroundIntensity)   % Set background intensity
             
@@ -163,7 +167,7 @@ classdef PresentImages < manookinlab.protocols.ManookinLabStageProtocol
             % Only allow image to be visible during specific time
             p.addStimulus(scene);
             sceneVisible = stage.builtin.controllers.PropertyController(scene, 'visible', ...
-                @(state)state.time >= obj.preTime * 1e-3 && state.time < (obj.preTime + obj.stimTime) * 1e-3);
+                @(state)state.frame >= obj.preFrames && state.frame < obj.preFrames + obj.stimFrames);
             p.addController(sceneVisible);
 
             % Control which image is visible.
@@ -285,6 +289,9 @@ classdef PresentImages < manookinlab.protocols.ManookinLabStageProtocol
             epoch.addParameter('magnificationFactor', obj.magnificationFactor);
             epoch.addParameter('flashFrames', obj.flashFrames);
             epoch.addParameter('gapFrames', obj.gapFrames);
+            epoch.addParameter('preFrames', obj.preFrames);
+            epoch.addParameter('tailFrames', obj.tailFrames);
+            epoch.addParameter('stimFrames', obj.stimFrames);
         end
 
         function stimTime = get.stimTime(obj)

--- a/StimulusPackages/celltyping-package/+manookinlab/+protocols/PresentImages.m
+++ b/StimulusPackages/celltyping-package/+manookinlab/+protocols/PresentImages.m
@@ -85,10 +85,11 @@ classdef PresentImages < manookinlab.protocols.ManookinLabStageProtocol
             obj.outerMaskRadiusPix = obj.rig.getDevice('Stage').um2pix(obj.outerMaskDiameter)/2.0;
             
             % Calcualate the number of flash and gap frames.
-            obj.preFrames = round((obj.preTime * 1e-3) * obj.expectedRefreshRate);
-            obj.flashFrames = round((obj.flashTime * 1e-3) * obj.expectedRefreshRate);
-            obj.gapFrames = round((obj.gapTime * 1e-3) * obj.expectedRefreshRate);
-            obj.tailFrames = round((obj.tailTime * 1e-3) * obj.expectedRefreshRate);
+            expectedRefreshRate = obj.rig.getDevice('Stage').getExpectedRefreshRate()
+            obj.preFrames = round((obj.preTime * 1e-3) * expectedRefreshRate);
+            obj.flashFrames = round((obj.flashTime * 1e-3) * expectedRefreshRate);
+            obj.gapFrames = round((obj.gapTime * 1e-3) * expectedRefreshRate);
+            obj.tailFrames = round((obj.tailTime * 1e-3) * expectedRefreshRate);
             obj.stimFrames = round((obj.flashFrames + obj.gapFrames) * obj.imagesPerEpoch);
             
             % General directory

--- a/StimulusPackages/celltyping-package/+manookinlab/+protocols/PresentImages.m
+++ b/StimulusPackages/celltyping-package/+manookinlab/+protocols/PresentImages.m
@@ -60,6 +60,9 @@ classdef PresentImages < manookinlab.protocols.ManookinLabStageProtocol
         imagesPerDir
         fullImagePaths
         validImageExtensions = {'.png','.jpg','.jpeg','.tif','.tiff'}
+        preFrames
+        tailFrames
+        stimFrames
         flashFrames
         gapFrames
         innerMaskRadiusPix
@@ -85,7 +88,7 @@ classdef PresentImages < manookinlab.protocols.ManookinLabStageProtocol
             obj.outerMaskRadiusPix = obj.rig.getDevice('Stage').um2pix(obj.outerMaskDiameter)/2.0;
             
             % Calcualate the number of flash and gap frames.
-            expectedRefreshRate = obj.rig.getDevice('Stage').getExpectedRefreshRate()
+            expectedRefreshRate = obj.rig.getDevice('Stage').getExpectedRefreshRate();
             obj.preFrames = round((obj.preTime * 1e-3) * expectedRefreshRate);
             obj.flashFrames = round((obj.flashTime * 1e-3) * expectedRefreshRate);
             obj.gapFrames = round((obj.gapTime * 1e-3) * expectedRefreshRate);

--- a/StimulusPackages/celltyping-package/+manookinlab/+protocols/PresentImages.m
+++ b/StimulusPackages/celltyping-package/+manookinlab/+protocols/PresentImages.m
@@ -60,6 +60,7 @@ classdef PresentImages < manookinlab.protocols.ManookinLabStageProtocol
         imagesPerDir
         fullImagePaths
         validImageExtensions = {'.png','.jpg','.jpeg','.tif','.tiff'}
+        expectedRefreshRate
         preFrames
         tailFrames
         stimFrames
@@ -88,11 +89,11 @@ classdef PresentImages < manookinlab.protocols.ManookinLabStageProtocol
             obj.outerMaskRadiusPix = obj.rig.getDevice('Stage').um2pix(obj.outerMaskDiameter)/2.0;
             
             % Calcualate the number of flash and gap frames.
-            expectedRefreshRate = obj.rig.getDevice('Stage').getExpectedRefreshRate();
-            obj.preFrames = round((obj.preTime * 1e-3) * expectedRefreshRate);
-            obj.flashFrames = round((obj.flashTime * 1e-3) * expectedRefreshRate);
-            obj.gapFrames = round((obj.gapTime * 1e-3) * expectedRefreshRate);
-            obj.tailFrames = round((obj.tailTime * 1e-3) * expectedRefreshRate);
+            obj.expectedRefreshRate = obj.rig.getDevice('Stage').getExpectedRefreshRate();
+            obj.preFrames = round((obj.preTime * 1e-3) * obj.expectedRefreshRate);
+            obj.flashFrames = round((obj.flashTime * 1e-3) * obj.expectedRefreshRate);
+            obj.gapFrames = round((obj.gapTime * 1e-3) * obj.expectedRefreshRate);
+            obj.tailFrames = round((obj.tailTime * 1e-3) * obj.expectedRefreshRate);
             obj.stimFrames = round((obj.flashFrames + obj.gapFrames) * obj.imagesPerEpoch);
             
             % General directory

--- a/StimulusPackages/celltyping-package/+manookinlab/+protocols/PresentImages.m
+++ b/StimulusPackages/celltyping-package/+manookinlab/+protocols/PresentImages.m
@@ -171,11 +171,8 @@ classdef PresentImages < manookinlab.protocols.ManookinLabStageProtocol
             p.addController(sceneVisible);
 
             % Control which image is visible.
-%             imgValue = stage.builtin.controllers.PropertyController(scene, ...
-%                 'imageMatrix', @(state)setImage(obj, state.time - obj.preTime*1e-3));
-            preF = floor(obj.preTime*1e-3 * 60);
             imgValue = stage.builtin.controllers.PropertyController(scene, ...
-                'imageMatrix', @(state)setImage(obj, state.frame - preF));
+                'imageMatrix', @(state)setImage(obj, state.frame - obj.preFrames));
             % Add the controller.
             p.addController(imgValue);
 


### PR DESCRIPTION
Issue: With 59.94 Hz actual framerate vs. Rig C Stage assuming 59 Hz, for a large number of imagesPerEpoch (like default 115) the last couple images are cut off (115th image never presents, 114th cut off during its flash time). 

Fix: Duration and visibility controller logic now uses frame counts computed using expected frame rate in config. Thanks to @drezeanu for showing how he did it using frame counts in [PresentMatFiles.m](https://github.com/DRezeanu/rezeanu-package/blob/master/%2Bedu/%2Bwashington/%2Briekelab/%2Bprotocols/PresentMatFiles.m)

Tested on Rig C, all images are now shown.