### PR TITLE
Clipping fix

### DIFF
--- a/StimulusPackages/celltyping-package/+manookinlab/+protocols/PresentImages.m
+++ b/StimulusPackages/celltyping-package/+manookinlab/+protocols/PresentImages.m
@@ -62,6 +62,7 @@ classdef PresentImages < manookinlab.protocols.ManookinLabStageProtocol
         fullImagePaths
         validImageExtensions = {'.png','.jpg','.jpeg','.tif','.tiff'}
         expectedRefreshRate
+        monitorRefreshRate
         preFrames
         tailFrames
         stimFrames
@@ -92,8 +93,10 @@ classdef PresentImages < manookinlab.protocols.ManookinLabStageProtocol
             % Calcualate the number of flash and gap frames.
             try
                 obj.expectedRefreshRate = obj.rig.getDevice('Stage').getExpectedRefreshRate();
+                obj.monitorRefreshRate = obj.rig.getDevice('Stage').getMonitorRefreshRate();
             catch
                 obj.expectedRefreshRate = 60.0;
+                obj.monitorRefreshRate = 60.0;
             end
             obj.preFrames = round((obj.preTime * 1e-3) * obj.expectedRefreshRate);
             obj.flashFrames = round((obj.flashTime * 1e-3) * obj.expectedRefreshRate);
@@ -159,7 +162,7 @@ classdef PresentImages < manookinlab.protocols.ManookinLabStageProtocol
                         perm = [perm, 1:nImgs]; %#ok<AGROW>
                     end
                 end
-            elseif nImgs > nNeeded
+            elseif nImgs >= nNeeded
                 % If more images than can be covered across epochs,
                 if obj.randomize
                     perm = randperm(nImgs);
@@ -179,7 +182,8 @@ classdef PresentImages < manookinlab.protocols.ManookinLabStageProtocol
         function p = createPresentation(obj)
             % Stage presets
             canvasSize = obj.rig.getDevice('Stage').getCanvasSize();     
-            totalTimePerEpoch = ceil((obj.preFrames + obj.stimFrames + obj.tailFrames)/obj.expectedRefreshRate);
+            % Total time based on monitor refresh rate as that's used by the Player to determine number of frames delivered.
+            totalTimePerEpoch = ceil((obj.preFrames + obj.stimFrames + obj.tailFrames)/obj.monitorRefreshRate);
             p = stage.core.Presentation(totalTimePerEpoch);
             
             p.setBackgroundColor(obj.backgroundIntensity)   % Set background intensity


### PR DESCRIPTION
A couple minor fixes:
- In `organize_image_sequences`, accounted for edge case when nImgs = nNeeded
- Thank you to Bella for pointing out issue from recent data when running a long epoch with large imagesPerEpoch. The issue is that the last few images get clipped, and you can see on Stage the presentation duration is terminated early, never getting to tail time and tail frames and stopping on something like the 10th to last image depending on the params. The issue is [RealTimePlayer](https://github.com/Stage-VSS/stage/blob/985d45c744cd40c3cf58f07f38111d6433112d3c/src/main/matlab/%2Bstage/%2Bbuiltin/%2Bplayers/RealtimePlayer.m) determines the number of frames to be delivered according to the specified duration and the refreshRate variable which is 59 in Rig C. This causes an underestimation of the number of frames needed to achieve the specified duration, leading to the clipping of last few images we observed. Fixed this by calculating duration using monitorRefreshRate, which appropriately compensates for this issue. Tested on Rig C for imagesPerEpoch = 576 using Bella's recent image folder. With the fix the protocol now successfully reaches tail frames and does not clip last few images.